### PR TITLE
Call callbacks more rapidly on startup and refresh token during connect

### DIFF
--- a/aioautomower/cli.py
+++ b/aioautomower/cli.py
@@ -13,7 +13,9 @@ async def run_tester(username: str, password: str, api_key: str):
     sess = aioautomower.AutomowerSession(api_key, ws_heartbeat_interval=60)
     token = await sess.login(username, password)
 
-    sess.register_cb(lambda x: logging.info("callback;%s" % x), schedule_immediately=False)
+    sess.register_cb(
+        lambda x: logging.info("callback;%s" % x), schedule_immediately=False
+    )
 
     await sess.connect()
 

--- a/aioautomower/cli.py
+++ b/aioautomower/cli.py
@@ -15,8 +15,7 @@ async def run_tester(username: str, password: str, api_key: str):
 
     sess.register_cb(lambda x: logging.info("callback;%s" % x))
 
-    if not await sess.connect():
-        _LOGGER.warning("Connect failed")
+    await sess.connect()
 
     def sigusr1():
         asyncio.ensure_future(sess.invalidate_token())

--- a/aioautomower/cli.py
+++ b/aioautomower/cli.py
@@ -13,7 +13,7 @@ async def run_tester(username: str, password: str, api_key: str):
     sess = aioautomower.AutomowerSession(api_key, ws_heartbeat_interval=60)
     token = await sess.login(username, password)
 
-    sess.register_cb(lambda x: logging.info("callback;%s" % x))
+    sess.register_cb(lambda x: logging.info("callback;%s" % x), schedule_immediately=False)
 
     await sess.connect()
 

--- a/aioautomower/rest.py
+++ b/aioautomower/rest.py
@@ -107,7 +107,7 @@ class RefreshAccessToken:
                     result["expires_at"] = result["expires_in"] + time.time()
                     result["status"] = resp.status
                     return result
-                if resp.status in [400, 404]:
+                elif resp.status in [400, 401, 404]:
                     raise TokenRefreshError(
                         f"The token cannot be refreshed, respone from Husqvarna Automower API: {resp.status}"
                     )


### PR DESCRIPTION
So, this is essentially two additions:
1. Make state updates more rapid during startup. Don't wait for the first websocket update to arrive before calling callbacks, but do it immediately on startup and possibly also on registering callbacks (since it might be a race between the two).
2. Refresh access token on connect instead of just bailing out if the expiry time has passed. The expiry time will always be old from home assistant since the config entry just contains the timestamp of the very first access token that was received during configuration.