### PR TITLE
Universal actions handling

### DIFF
--- a/aioautomower/rest.py
+++ b/aioautomower/rest.py
@@ -170,13 +170,23 @@ class GetMowerData:
 class Return:
     """Class to send commands to the Automower Connect API."""
 
-    def __init__(self, api_key, access_token, provider, token_type, mower_id, payload):
+    def __init__(
+        self,
+        api_key,
+        access_token,
+        provider,
+        token_type,
+        mower_id,
+        payload,
+        command_type,
+    ):
         """Initialize the API and store the auth so we can send commands."""
         self.api_key = api_key
         self.access_token = access_token
         self.provider = provider
         self.token_type = token_type
         self.mower_id = mower_id
+        self.command_type = command_type
         self.mower_headers = {
             "Authorization": "{0} {1}".format(self.token_type, self.access_token),
             "Authorization-Provider": "{0}".format(self.provider),
@@ -184,7 +194,9 @@ class Return:
             "accept": "*/*",
             "X-Api-Key": "{0}".format(self.api_key),
         }
-        self.mower_action_url = f"{MOWER_API_BASE_URL}{self.mower_id}/actions"
+        self.mower_action_url = (
+            f"{MOWER_API_BASE_URL}{self.mower_id}/{self.command_type}"
+        )
         self.payload = payload
 
     async def async_mower_command(self):
@@ -192,6 +204,7 @@ class Return:
         async with aiohttp.ClientSession(headers=self.mower_headers) as session:
             async with session.post(self.mower_action_url, data=self.payload) as resp:
                 result = await session.close()
+        _LOGGER.debug("Mower Action URL: %s", self.mower_action_url)
         _LOGGER.debug("Sent payload: %s", self.payload)
         _LOGGER.debug("Resp status mower command: %s", resp.status)
         return resp.status

--- a/aioautomower/rest.py
+++ b/aioautomower/rest.py
@@ -160,6 +160,7 @@ class GetMowerData:
                 _LOGGER.debug("Resp.status mower data: %i", resp.status)
                 if resp.status == 200:
                     result = await resp.json(encoding="UTF-8")
+                    _LOGGER.debug("Result: %s", result)
                 if resp.status >= 400:
                     resp.raise_for_status()
         result["status"] = resp.status

--- a/aioautomower/session.py
+++ b/aioautomower/session.py
@@ -8,11 +8,11 @@ import aiohttp
 from . import rest
 from .const import (
     AUTH_HEADER_FMT,
-    HUSQVARNA_URL,
-    WS_URL,
-    MIN_SLEEP_TIME,
-    MARGIN_TIME,
     EVENT_TYPES,
+    HUSQVARNA_URL,
+    MARGIN_TIME,
+    MIN_SLEEP_TIME,
+    WS_URL,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -154,7 +154,7 @@ class AutomowerSession:
         )
         return await d.async_mower_state()
 
-    async def action(self, mower_id, payload):
+    async def action(self, mower_id, payload, command_type):
         """Send command to the mower via Rest."""
         if self.token is None:
             _LOGGER.warning("No token available")
@@ -166,6 +166,7 @@ class AutomowerSession:
             self.token["token_type"],
             mower_id,
             payload,
+            command_type,
         )
         return await a.async_mower_command()
 

--- a/aioautomower/session.py
+++ b/aioautomower/session.py
@@ -207,7 +207,7 @@ class AutomowerSession:
             else:
                 sleep_time = MIN_SLEEP_TIME
 
-            _LOGGER.debug("_token_monitor_task sleeping for %s sec", sleep_time)
+            _LOGGER.debug("token_monitor_task sleeping for %s sec", sleep_time)
             await asyncio.sleep(sleep_time)
             await self.refresh_token()
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=list(val.strip() for val in open("requirements.txt")),
-    version="2021.10.3",
+    version="2021.11.0",
     entry_points={
         "console_scripts": ["automower=aioautomower.cli:main"],
     },


### PR DESCRIPTION
Allows to addresses other mower_urls than https://api.amc.husqvarna.dev/v1/mowers/xxxxx-xxxx-xx/actions. Last part can now be set individual. This is required for new command types apart from `actions`, like `settings` and `calendar`