### PR TITLE
Handle empty tasks

### DIFF
--- a/aioautomower/session.py
+++ b/aioautomower/session.py
@@ -230,8 +230,11 @@ class AutomowerSession:
                 for attrib in j["attributes"]:
                     try:
                         tasks = j["attributes"]["calendar"]["tasks"]
+                        _LOGGER.debug("tasks %s", tasks)
                         if len(tasks) == 0:
-                            pass
+                            temp_task = datum["attributes"]["calendar"]["tasks"]
+                            datum["attributes"][attrib] = j["attributes"][attrib]
+                            datum["attributes"]["calendar"]["tasks"] = temp_task
                         if len(tasks) > 0:
                             datum["attributes"][attrib] = j["attributes"][attrib]
                     except KeyError:

--- a/aioautomower/session.py
+++ b/aioautomower/session.py
@@ -232,7 +232,7 @@ class AutomowerSession:
                         tasks = j["attributes"]["calendar"]["tasks"]
                         if len(tasks) == 0:
                             temp_task = datum["attributes"]["calendar"]["tasks"]
-                            datum["attributes"][attrib] = j["attributes"][attrib].copy()
+                            datum["attributes"][attrib] = j["attributes"][attrib]
                             datum["attributes"]["calendar"]["tasks"] = temp_task
                         if len(tasks) > 0:
                             datum["attributes"][attrib] = j["attributes"][attrib]

--- a/aioautomower/session.py
+++ b/aioautomower/session.py
@@ -230,10 +230,9 @@ class AutomowerSession:
                 for attrib in j["attributes"]:
                     try:
                         tasks = j["attributes"]["calendar"]["tasks"]
-                        _LOGGER.debug("tasks %s", tasks)
                         if len(tasks) == 0:
                             temp_task = datum["attributes"]["calendar"]["tasks"]
-                            datum["attributes"][attrib] = j["attributes"][attrib]
+                            datum["attributes"][attrib] = j["attributes"][attrib].copy()
                             datum["attributes"]["calendar"]["tasks"] = temp_task
                         if len(tasks) > 0:
                             datum["attributes"][attrib] = j["attributes"][attrib]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=list(val.strip() for val in open("requirements.txt")),
-    version="2022.7.2",
+    version="2022.8.0",
     entry_points={
         "console_scripts": ["automower=aioautomower.cli:main"],
     },


### PR DESCRIPTION
Events liked this:
```2022-08-12 17:01:08.952 DEBUG (MainThread) [aioautomower.session] Got settings-event, data: {'id': 'b2bc3443-b31a-4c7f-834e-d6e408c53f1b', 'type': 'settings-event', 'attributes': {'calendar': {'tasks': []}, 'headlight': {'mode': 'EVENING_ONLY'}}}```
were completely ignored, because tasks are empty. This PR includes changes in a setting event with an empty tasks.
In the past I think only these empty task events were sent from the websocket:
```2022-08-12 17:01:08.952 DEBUG (MainThread) [aioautomower.session] Got settings-event, data: {'id': 'b2bc3443-b31a-4c7f-834e-d6e408c53f1b', 'type': 'settings-event', 'attributes': {'calendar': {'tasks': []}}}```
So it was possible to ignore them completely.