### PR TITLE
revoke function

### DIFF
--- a/aioautomower/const.py
+++ b/aioautomower/const.py
@@ -1,6 +1,7 @@
 """The constants for aioautomower."""
 AUTH_API_BASE_URL = "https://api.authentication.husqvarnagroup.dev/v1"
-AUTH_API_URL = f"{AUTH_API_BASE_URL}/oauth2/token"
+AUTH_API_TOKEN_URL = f"{AUTH_API_BASE_URL}/oauth2/token"
+AUTH_API_REVOKE_URL = f"{AUTH_API_BASE_URL}/oauth2/revoke"
 AUTH_HEADERS = {
     "Content-Type": "application/x-www-form-urlencoded",
     "Accept": "application/json",

--- a/aioautomower/session.py
+++ b/aioautomower/session.py
@@ -138,8 +138,7 @@ class AutomowerSession:
 
     async def close(self):
         """Close the session."""
-        revoke = rest.RevokeAccessToken(self.token["access_token"])
-        await revoke.async_delete_access_token()
+        await self.invalidate_token()
         for task in [
             self.ws_task,
             self.token_task,
@@ -190,9 +189,6 @@ class AutomowerSession:
         if self.token is None:
             _LOGGER.warning("No token available")
             return None
-        # token = rest.HandleAccessToken(
-        #     self.api_key, self.token["access_token"], self.token["provider"]
-        # )
         token = rest.RevokeAccessToken(self.token["access_token"])
         return await token.async_delete_access_token()
 

--- a/aioautomower/session.py
+++ b/aioautomower/session.py
@@ -138,6 +138,8 @@ class AutomowerSession:
 
     async def close(self):
         """Close the session."""
+        revoke = rest.RevokeAccessToken(self.token["access_token"])
+        await revoke.async_delete_access_token()
         for task in [
             self.ws_task,
             self.token_task,
@@ -188,9 +190,10 @@ class AutomowerSession:
         if self.token is None:
             _LOGGER.warning("No token available")
             return None
-        token = rest.HandleAccessToken(
-            self.api_key, self.token["access_token"], self.token["provider"]
-        )
+        # token = rest.HandleAccessToken(
+        #     self.api_key, self.token["access_token"], self.token["provider"]
+        # )
+        token = rest.RevokeAccessToken(self.token["access_token"])
         return await token.async_delete_access_token()
 
     async def refresh_token(self):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=list(val.strip() for val in open("requirements.txt")),
-    version="2022.9.1",
+    version="2023.3.0",
     entry_points={
         "console_scripts": ["automower=aioautomower.cli:main"],
     },


### PR DESCRIPTION
Delete a token with `DELETE` is not possible anymore. So the Class `HandleAccessToken` is replaced by `RevokeAccessToken` with `POST` command