### PR TITLE
Increase margin time for refresh token

### DIFF
--- a/aioautomower/const.py
+++ b/aioautomower/const.py
@@ -13,7 +13,7 @@ EVENT_TYPES = [
     "settings-event",
 ]
 HUSQVARNA_URL = "https://developer.husqvarnagroup.cloud/"
-MARGIN_TIME = 60.0  # Token is typically valid for 24h, request a new one some time before its expiration to avoid glitches.
+MARGIN_TIME = 3600.0  # Token is typically valid for 24h, request a new one some time before its expiration to avoid glitches.
 MIN_SLEEP_TIME = 600.0  # Avoid hammering
 MOWER_API_BASE_URL = "https://api.amc.husqvarna.dev/v1/mowers/"
 REST_POLL_CYCLE = 300

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=list(val.strip() for val in open("requirements.txt")),
-    version="2023.4.2",
+    version="2023.4.3",
     entry_points={
         "console_scripts": ["automower=aioautomower.cli:main"],
     },


### PR DESCRIPTION
Increase margin time, because token can't be updated anymore. JWT content says:
"exp": 1680793833, (15:10:33 in GMT)
Everything worked until 14:48:12, then I got this error message:
2023-04-06 14:48:12.379 DEBUG (MainThread) [aioautomower.rest] Response mower data: <ClientResponse(https://api.amc.husqvarna.dev/v1/mowers/) [403 Forbidden]>
<CIMultiDictProxy('Content-Type': 'application/vnd.api+json', 'Content-Length': '181', 'Connection': 'keep-alive', 'Date': 'Thu, 06 Apr 2023 14:48:12 GMT', 'x-amzn-RequestId': '8fe793e1-24a5-455b-a6c1-a9229d786460', 'x-amzn-Remapped-Content-Length': '181', 'x-amzn-Remapped-Connection': 'keep-alive', 'x-amz-apigw-id': 'C9dC-EcGjoEF-jQ=', 'x-amzn-Remapped-Date': 'Thu, 06 Apr 2023 14:48:12 GMT', 'X-Cache': 'Error from cloudfront', 'Via': '1.1 36782ce80608b4ebb0112f2f4fdd01be.cloudfront.net (CloudFront)', 'X-Amz-Cf-Pop': 'AMS50-C1', 'X-Amz-Cf-Id': 'S8MiyDtUU-a1aWu11koRBZDHDUmysbn2FMV4TWn-MGsnVJzzoLPekg==')>
When trying to refresh the token 60s before the expiration, I got this message: 2023-04-06 15:09:32.872 DEBUG (MainThread) [aioautomower.rest] Resp.status refresh token: {'error': 'invalid_grant', 'error_description': 'Failed to find token', 'error_code': 'token.not.found'}