### PR TITLE
Add errors_confirm API

### DIFF
--- a/src/aioautomower/session.py
+++ b/src/aioautomower/session.py
@@ -43,6 +43,9 @@ class AutomowerEndpoint:
     work_area_calendar = "mowers/{mower_id}/workAreas/{work_area_id}/calendar"
     "Update the calendar for a work area on the mower."
 
+    error_confirm = "mowers/{mower_id}/errors/confirm"
+    "Confirm mower non-fatal error"
+
 
 class AutomowerSession:
     """Automower API to communicate with an Automower.
@@ -323,6 +326,12 @@ class AutomowerSession:
             mower_id=mower_id, stay_out_id=stay_out_zone_id
         )
         await self.auth.patch_json(url, json=body)
+
+    async def error_confirm(self, mower_id: str):
+        """Confirm non-fatal mower error."""
+        body = {}
+        url = AutomowerEndpoint.error_confirm.format(mower_id=mower_id)
+        await self.auth.post_json(url, json=body)
 
     def _update_data(self, new_data):
         if self._data is None:

--- a/src/aioautomower/session.py
+++ b/src/aioautomower/session.py
@@ -329,7 +329,7 @@ class AutomowerSession:
 
     async def error_confirm(self, mower_id: str):
         """Confirm non-fatal mower error."""
-        body = {}
+        body = {} # type: dict[str, str]
         url = AutomowerEndpoint.error_confirm.format(mower_id=mower_id)
         await self.auth.post_json(url, json=body)
 

--- a/src/aioautomower/session.py
+++ b/src/aioautomower/session.py
@@ -56,6 +56,7 @@ class AutomowerSession:
 
     # pylint: disable=too-many-instance-attributes
     # pylint: disable=too-many-nested-blocks
+    # pylint: disable=too-many-public-methods
 
     def __init__(
         self,
@@ -329,7 +330,7 @@ class AutomowerSession:
 
     async def error_confirm(self, mower_id: str):
         """Confirm non-fatal mower error."""
-        body = {} # type: dict[str, str]
+        body = {}  # type: dict[str, str]
         url = AutomowerEndpoint.error_confirm.format(mower_id=mower_id)
         await self.auth.post_json(url, json=body)
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -97,6 +97,12 @@ async def test_connect(
         f"mowers/{MOWER_ID}/calendar",
         json={"data": {"type": "calendar", "attributes": {"tasks": task_list}}},
     )
+    await automower_api.error_confirm(MOWER_ID)
+    assert mocked_method.call_count == 10
+    mocked_method.assert_called_with(
+        f"mowers/{mower_id}/errors/confirm",
+        json={}
+    )
     mocked_method.reset_mock()
     setattr(mock_automower_client, "patch_json", mocked_method)
     await automower_api.switch_stay_out_zone(MOWER_ID, "fake", True)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -100,7 +100,7 @@ async def test_connect(
     await automower_api.error_confirm(MOWER_ID)
     assert mocked_method.call_count == 10
     mocked_method.assert_called_with(
-        f"mowers/{mower_id}/errors/confirm",
+        f"mowers/{MOWER_ID}/errors/confirm",
         json={}
     )
     mocked_method.reset_mock()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -99,10 +99,7 @@ async def test_connect(
     )
     await automower_api.error_confirm(MOWER_ID)
     assert mocked_method.call_count == 10
-    mocked_method.assert_called_with(
-        f"mowers/{MOWER_ID}/errors/confirm",
-        json={}
-    )
+    mocked_method.assert_called_with(f"mowers/{MOWER_ID}/errors/confirm", json={})
     mocked_method.reset_mock()
     setattr(mock_automower_client, "patch_json", mocked_method)
     await automower_api.switch_stay_out_zone(MOWER_ID, "fake", True)


### PR DESCRIPTION
**Description**
This PR proposes adding support for `/mowers/{id}/errors/confirm` API endpoint to reset non-fatal mower errors. 

**Why it's important**
Automower can go into ERROR state for any number of reasons. Certain non-fatal errors can be reset remotely (see [example](https://www.youtube.com/watch?v=0UjBZm2DvX4#t=1m38s)) via Husqvarna app so the mower can continue with it's schedule. For example, I use [this gate](https://store.smart-dots.com/product-details/626c6f0d05b0ca664defa2f1) with my Automower and occasionally the mower fails to get through the gate, thereby going into ERROR state. Most of the time, I can reset the error via Husqvarna app and resume schedule. I'd like to do this through automation to minimize human intervention. 

**Next Steps**
Add support for "Reset Error" call in [husqvarna_automower](https://www.home-assistant.io/integrations/husqvarna_automower/) Home Assistant integration that depends on this aioautomower library. 