### PR TITLE
Avoid double events

### DIFF
--- a/src/aioautomower/session.py
+++ b/src/aioautomower/session.py
@@ -316,13 +316,13 @@ class AutomowerSession:
                 self._schedule_message_callbacks(self.messages[mower_id])
             if not self.messages:
                 single_message = SingleMessageData.from_dict(new_data)
-                if single_message == self.single_message:
-                    _LOGGER.debug(
-                        "Received same single message as before, not updating."
-                    )
                 if single_message != self.single_message:
                     self.single_message = single_message
                     self._schedule_single_message_callbacks(self.single_message)
+                else:
+                    _LOGGER.debug(
+                        "Received same single message as before, not updating."
+                    )
 
         if self._data is None:
             raise NoDataAvailableError

--- a/src/aioautomower/session.py
+++ b/src/aioautomower/session.py
@@ -55,6 +55,7 @@ class AutomowerSession:
         "poll",
         "pong_cbs",
         "rest_task",
+        "single_message",
         "single_message_cbs",
     )
 
@@ -82,6 +83,7 @@ class AutomowerSession:
         self.loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
         self.message_update_cbs: list[tuple[str, Callable[[MessageData], None]]] = []
         self.single_message_cbs: list[Callable[[SingleMessageData], None]] = []
+        self.single_message: SingleMessageData | None = None
         self.messages: dict[str, MessageData] = {}
         self.poll = poll
         self.pong_cbs: list[Callable[[datetime.datetime], None]] = []
@@ -314,7 +316,13 @@ class AutomowerSession:
                 self._schedule_message_callbacks(self.messages[mower_id])
             if not self.messages:
                 single_message = SingleMessageData.from_dict(new_data)
-                self._schedule_single_message_callbacks(single_message)
+                if single_message == self.single_message:
+                    _LOGGER.debug(
+                        "Received same single message as before, not updating."
+                    )
+                if single_message != self.single_message:
+                    self.single_message = single_message
+                    self._schedule_single_message_callbacks(self.single_message)
 
         if self._data is None:
             raise NoDataAvailableError


### PR DESCRIPTION
In most cases the mower sends the message twice. So the second gets filtered.