### PR TITLE
Rename Type enum to WorkAreaType and export it

### DIFF
--- a/src/aioautomower/model/__init__.py
+++ b/src/aioautomower/model/__init__.py
@@ -53,7 +53,7 @@ from .model_token import (
     JWT,
     User,
 )
-from .model_work_areas import WorkArea
+from .model_work_areas import WorkArea, WorkAreaType
 
 __all__ = [
     "JWT",
@@ -95,6 +95,7 @@ __all__ = [
     "TimeSerializationStrategy",
     "User",
     "WorkArea",
+    "WorkAreaType",
     "Zone",
     "convert_timestamp_to_aware_datetime",
     "error_key_dict",

--- a/src/aioautomower/model/model_work_areas.py
+++ b/src/aioautomower/model/model_work_areas.py
@@ -1,5 +1,6 @@
 """Models for Automower Connect API - WorkAreas."""
 
+import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
@@ -16,8 +17,22 @@ class WorkAreaType(StrEnum):
     SYSTEMATIC = "systematic"
 
 
-# Backwards compatible alias for the previous, generic name.
-Type = WorkAreaType
+def __getattr__(name: str) -> object:
+    """Provide a deprecated alias for the previous, generic ``Type`` name.
+
+    Accessing ``aioautomower.model.model_work_areas.Type`` keeps working but
+    emits a DeprecationWarning so downstream consumers can migrate.
+    """
+    if name == "Type":
+        warnings.warn(
+            "aioautomower.model.model_work_areas.Type is deprecated, "
+            "use WorkAreaType instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return WorkAreaType
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
 
 
 @dataclass

--- a/src/aioautomower/model/model_work_areas.py
+++ b/src/aioautomower/model/model_work_areas.py
@@ -9,11 +9,15 @@ from mashumaro import DataClassDictMixin, field_options
 from .utils import convert_timestamp_to_aware_datetime
 
 
-class Type(StrEnum):
+class WorkAreaType(StrEnum):
     """Types of work areas."""
 
     RANDOM = "random"
     SYSTEMATIC = "systematic"
+
+
+# Backwards compatible alias for the previous, generic name.
+Type = WorkAreaType
 
 
 @dataclass
@@ -25,8 +29,10 @@ class WorkArea(DataClassDictMixin):
             deserialize=lambda x: "my_lawn" if x == "" else x,
         ),
     )
-    type: Type = field(
-        metadata=field_options(deserialize=lambda x: Type(x.lower()), alias="type")
+    type: WorkAreaType = field(
+        metadata=field_options(
+            deserialize=lambda x: WorkAreaType(x.lower()), alias="type"
+        )
     )
     cutting_height: int = field(metadata=field_options(alias="cuttingHeight"))
     use_global_cutting_height: bool = field(

--- a/tests/__snapshots__/test_high_feature_mower_model.ambr
+++ b/tests/__snapshots__/test_high_feature_mower_model.ambr
@@ -268,7 +268,7 @@
       'orientation': None,
       'orientation_shift': None,
       'progress': 20,
-      'type': <Type.SYSTEMATIC: 'systematic'>,
+      'type': <WorkAreaType.SYSTEMATIC: 'systematic'>,
       'use_global_cutting_height': True,
     }),
     123456: dict({
@@ -281,7 +281,7 @@
       'orientation': 1800,
       'orientation_shift': 1800,
       'progress': 40,
-      'type': <Type.SYSTEMATIC: 'systematic'>,
+      'type': <WorkAreaType.SYSTEMATIC: 'systematic'>,
       'use_global_cutting_height': True,
     }),
     654321: dict({
@@ -294,7 +294,7 @@
       'orientation': None,
       'orientation_shift': None,
       'progress': None,
-      'type': <Type.RANDOM: 'random'>,
+      'type': <WorkAreaType.RANDOM: 'random'>,
       'use_global_cutting_height': True,
     }),
   })

--- a/tests/test_work_area_type.py
+++ b/tests/test_work_area_type.py
@@ -1,7 +1,10 @@
 """Tests for the WorkAreaType enum."""
 
-from aioautomower.model import WorkAreaType
-from aioautomower.model.model_work_areas import Type
+import warnings
+
+import pytest
+
+from aioautomower.model import WorkArea, WorkAreaType
 
 
 def test_work_area_type_values() -> None:
@@ -16,8 +19,54 @@ def test_work_area_type_from_api_strings() -> None:
     assert WorkAreaType("random") is WorkAreaType.RANDOM
 
 
-def test_legacy_type_alias() -> None:
-    """Verify the previous Type name still resolves to the same enum."""
-    assert Type is WorkAreaType
-    assert Type.SYSTEMATIC is WorkAreaType.SYSTEMATIC
-    assert Type.RANDOM is WorkAreaType.RANDOM
+@pytest.mark.parametrize(
+    ("api_value", "expected"),
+    [
+        ("SYSTEMATIC", WorkAreaType.SYSTEMATIC),
+        ("RANDOM", WorkAreaType.RANDOM),
+        ("systematic", WorkAreaType.SYSTEMATIC),
+        ("random", WorkAreaType.RANDOM),
+        ("Systematic", WorkAreaType.SYSTEMATIC),
+    ],
+)
+def test_work_area_deserialize_api_payload(
+    api_value: str, expected: WorkAreaType
+) -> None:
+    """Verify the WorkArea deserializer accepts the casing variants the API sends.
+
+    The Husqvarna Automower Connect API returns the work area type as an
+    uppercase string (for example ``SYSTEMATIC``), so the dataclass deserializer
+    must lowercase the value before constructing the enum. This regression test
+    locks that behaviour in so the HA Core integration keeps deserializing.
+    """
+    payload = {
+        "name": "test_area",
+        "type": api_value,
+        "cuttingHeight": 50,
+        "useGlobalCuttingHeight": True,
+        "enabled": True,
+    }
+    work_area = WorkArea.from_dict(payload)
+    assert work_area.type is expected
+
+
+def test_legacy_type_alias_emits_deprecation_warning() -> None:
+    """Verify the previous Type name still resolves but warns on access."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        from aioautomower.model.model_work_areas import Type  # noqa: PLC0415
+
+        assert Type is WorkAreaType
+        assert any(
+            issubclass(w.category, DeprecationWarning)
+            and "WorkAreaType" in str(w.message)
+            for w in caught
+        )
+
+
+def test_legacy_type_alias_unknown_attribute() -> None:
+    """Verify unknown attributes still raise AttributeError."""
+    import aioautomower.model.model_work_areas as module  # noqa: PLC0415
+
+    with pytest.raises(AttributeError):
+        module.DoesNotExist  # noqa: B018

--- a/tests/test_work_area_type.py
+++ b/tests/test_work_area_type.py
@@ -1,0 +1,23 @@
+"""Tests for the WorkAreaType enum."""
+
+from aioautomower.model import WorkAreaType
+from aioautomower.model.model_work_areas import Type
+
+
+def test_work_area_type_values() -> None:
+    """Verify the public string values map to the Husqvarna API payload."""
+    assert WorkAreaType.RANDOM.value == "random"
+    assert WorkAreaType.SYSTEMATIC.value == "systematic"
+
+
+def test_work_area_type_from_api_strings() -> None:
+    """Verify lowercased values from the API payload deserialize cleanly."""
+    assert WorkAreaType("systematic") is WorkAreaType.SYSTEMATIC
+    assert WorkAreaType("random") is WorkAreaType.RANDOM
+
+
+def test_legacy_type_alias() -> None:
+    """Verify the previous Type name still resolves to the same enum."""
+    assert Type is WorkAreaType
+    assert Type.SYSTEMATIC is WorkAreaType.SYSTEMATIC
+    assert Type.RANDOM is WorkAreaType.RANDOM


### PR DESCRIPTION
## Summary

Rename the `Type` enum in `aioautomower.model.model_work_areas` to `WorkAreaType`, keep `Type` as a backwards compatible alias, and export `WorkAreaType` from `aioautomower.model`.

## Why

The current public surface only exports `WorkArea`. The enum that discriminates between `RANDOM` and `SYSTEMATIC` work-areas is internal and named `Type`, which collides with `typing.Type` in downstream consumers and is not very discoverable via the package namespace.

Home Assistant core PR home-assistant/core#168567 needs a stable, importable name for this enum to gate work-area sensors that only carry `progress`, `lastTimeCompleted`, and the `orientation` triple on `SYSTEMATIC` areas. `RANDOM` areas never report those fields, so the cleanest filter is `data.type == WorkAreaType.SYSTEMATIC` rather than `None` checks on each individual value.

## Changes

- `model_work_areas.py`: rename `Type` to `WorkAreaType`, alias `Type = WorkAreaType` for backwards compatibility, update the `WorkArea.type` annotation and the `deserialize` callable.
- `model/__init__.py`: re-export `WorkAreaType` and add it to `__all__`.
- `tests/test_work_area_type.py`: cover the enum values, the API string deserialization, and the legacy `Type` alias.

## Backwards compatibility

`Type` keeps resolving to the same enum object via the alias, so any existing import like `from aioautomower.model.model_work_areas import Type` continues to work.

## Notes

Happy to adjust the alias removal timeline (deprecation warning, removal in next major, etc.) if that fits the project policy better. Marked as draft until a maintainer confirms the rename direction.
