### PR TITLE
ci: use locked uv sync

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ jobs:
           enable-cache: true
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: 🏗 Install dependencies
-        run: uv sync
+        run: uv sync --locked
       - name: Run benchmarks
         uses: CodSpeedHQ/action@v4.19.1
         with:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -24,7 +24,7 @@ jobs:
           enable-cache: true
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: 🏗 Install Python dependencies
-        run: uv sync
+        run: uv sync --locked
       - name: 🚀 Check code for common misspellings
         run: uv run prek run codespell --all-files
 
@@ -40,7 +40,7 @@ jobs:
           enable-cache: true
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: 🏗 Install Python dependencies
-        run: uv sync
+        run: uv sync --locked
       - name: 🚀 Run ruff linter
         run: uv run ruff check --output-format=github
       - name: 🚀 Run ruff formatter
@@ -58,7 +58,7 @@ jobs:
           enable-cache: true
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: 🏗 Install Python dependencies
-        run: uv sync
+        run: uv sync --locked
       - name: 🚀 Check Python AST
         run: uv run prek run check-ast --all-files
       - name: 🚀 Check for case conflicts
@@ -98,6 +98,6 @@ jobs:
           enable-cache: true
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: 🏗 Install Python dependencies
-        run: uv sync
+        run: uv sync --locked
       - name: 🚀 Run yamllint
         run: uv run yamllint .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python }}
       - name: 🏗 Install dependencies
-        run: uv sync
+        run: uv sync --locked
       - name: 🚀 Run pytest
         run: uv run pytest --cov src tests
       - name: ⬆️ Upload coverage artifact
@@ -55,7 +55,7 @@ jobs:
           enable-cache: true
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: 🏗 Install dependencies
-        run: uv sync
+        run: uv sync --locked
       - name: 🚀 Process coverage results
         run: |
           uv run coverage combine coverage*/.coverage*

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -25,6 +25,6 @@ jobs:
           enable-cache: true
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: 🏗 Install dependencies
-        run: uv sync
+        run: uv sync --locked
       - name: 🚀 Run ty
         run: uv run ty check src


### PR DESCRIPTION
## Summary

- use `uv sync --locked` in CI workflows
- keep the checked-in `uv.lock` authoritative during CI
- leave `actions/checkout` in place because the workflows need repository files

The existing lockfile workflow already runs `uv lock --check`, so CI now consistently fails instead of silently resolving a different environment when the lockfile is stale.