### PR TITLE
chore: remove unused type stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,6 @@ dev = [
   "syrupy==5.5.3",
   "time-machine==3.4.0",
   "ty==0.0.62",
-  "types-python-dateutil==2.9.0.20240821",
-  "types-pyyaml==6.0.12.20241230",
   "yamllint==1.38.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -36,8 +36,6 @@ dev = [
     { name = "syrupy" },
     { name = "time-machine" },
     { name = "ty" },
-    { name = "types-python-dateutil" },
-    { name = "types-pyyaml" },
     { name = "yamllint" },
 ]
 
@@ -68,8 +66,6 @@ dev = [
     { name = "syrupy", specifier = "==5.5.3" },
     { name = "time-machine", specifier = "==3.4.0" },
     { name = "ty", specifier = "==0.0.62" },
-    { name = "types-python-dateutil", specifier = "==2.9.0.20240821" },
-    { name = "types-pyyaml", specifier = "==6.0.12.20241230" },
     { name = "yamllint", specifier = "==1.38.0" },
 ]
 
@@ -1406,24 +1402,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/27/08505fa0d2bef8fe4107753bb02ed2da4e323103ff5d423b9cc9eea4346e/ty-0.0.62-py3-none-win32.whl", hash = "sha256:254690c758e9d0ee2c8dfe07320d4e9d54709d5e95fa588ecf5a96391dc8d8d4", size = 11381070, upload-time = "2026-07-22T01:02:36.625Z" },
     { url = "https://files.pythonhosted.org/packages/aa/c1/609840f13d1c48e88e5b431fe789650da14cb25da0df2979fe08ce422e73/ty-0.0.62-py3-none-win_amd64.whl", hash = "sha256:d88c2594e6a33c5f859c1d9016ad6137ec304c5d51422ce48894d2b9393956a7", size = 12415015, upload-time = "2026-07-22T01:02:39.193Z" },
     { url = "https://files.pythonhosted.org/packages/0f/a8/43f838fa38922f175a223814120b5faeb1bb6e5ef1533e45f543c0f510b8/ty-0.0.62-py3-none-win_arm64.whl", hash = "sha256:11b5e7df21890bef3eda49ae15a0c4d12554917ec4ea90ea985caa33241af627", size = 11773787, upload-time = "2026-07-22T01:02:41.564Z" },
-]
-
-[[package]]
-name = "types-python-dateutil"
-version = "2.9.0.20240821"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/23/11/aae06ddb6a90cf8ba078be6dbe47f904d2efdf451f9859248b436c945ca4/types-python-dateutil-2.9.0.20240821.tar.gz", hash = "sha256:9649d1dcb6fef1046fb18bebe9ea2aa0028b160918518c34589a46045f6ebd98", size = 9122, upload-time = "2024-08-21T02:30:25.002Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/ba/2a4750156272f180f8209f87656ae92e0aeb14f9864976aa90cbd9f21eda/types_python_dateutil-2.9.0.20240821-py3-none-any.whl", hash = "sha256:f5889fcb4e63ed4aaa379b44f93c32593d50b9a94c9a60a0c854d8cc3511cd57", size = 9668, upload-time = "2024-08-21T02:30:23.508Z" },
-]
-
-[[package]]
-name = "types-pyyaml"
-version = "6.0.12.20241230"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9a/f9/4d566925bcf9396136c0a2e5dc7e230ff08d86fa011a69888dd184469d80/types_pyyaml-6.0.12.20241230.tar.gz", hash = "sha256:7f07622dbd34bb9c8b264fe860a17e0efcad00d50b5f27e93984909d9363498c", size = 17078, upload-time = "2024-12-30T02:44:38.168Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/c1/48474fbead512b70ccdb4f81ba5eb4a58f69d100ba19f17c92c0c4f50ae6/types_PyYAML-6.0.12.20241230-py3-none-any.whl", hash = "sha256:fa4d32565219b68e6dee5f67534c722e53c00d1cfc09c435ef04d7353e1e96e6", size = 20029, upload-time = "2024-12-30T02:44:36.162Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- remove `types-python-dateutil`
- remove `types-pyyaml`

These type-stub packages were used for the previous mypy setup and are no longer needed after migrating to ty.

The lockfile should be regenerated with `uv lock` as part of this change.