### PR TITLE
Remove redundant codespell workflow job

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,22 +12,6 @@ env:
   DEFAULT_PYTHON: "3.11"
 
 jobs:
-  codespell:
-    name: codespell
-    runs-on: ubuntu-latest
-    steps:
-      - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@v7.0.1
-      - name: 🏗 Set up uv
-        uses: astral-sh/setup-uv@v10.0.1
-        with:
-          enable-cache: true
-          python-version: ${{ env.DEFAULT_PYTHON }}
-      - name: 🏗 Install Python dependencies
-        run: uv sync --locked
-      - name: 🚀 Check code for common misspellings
-        run: uv run prek run codespell --all-files
-
   ruff:
     name: Ruff
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- remove the dedicated `codespell` GitHub Actions job
- keep codespell covered by the existing `prek-hooks` job

The repository's `.pre-commit-config.yaml` already defines the `codespell` hook, so running `uv run prek run codespell --all-files` separately duplicates the same check. The existing `prek-hooks` job is the central place for these prek-managed checks.

## Testing

The existing `prek-hooks` job continues to run the configured hooks, including codespell.