### PR TITLE
Skip no-commit-to-branch hook in CI

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -27,5 +27,6 @@ jobs:
         run: uv sync --locked
       - name: 🚀 Run all prek hooks
         env:
+          SKIP: no-commit-to-branch
           TZ: Europe/Berlin
         run: uv run prek run --all-files


### PR DESCRIPTION
## Summary

- skip the `no-commit-to-branch` prek hook in the linting CI job
- keep the hook enabled for local commits
- retain the `TZ=Europe/Berlin` setting for the test suite

The `no-commit-to-branch` hook is intended to prevent local commits directly to `main`. When the workflow runs on `main` after a merge, it sees the checked-out `main` branch and correctly rejects it, causing CI to fail. Skipping this local-only guard in CI keeps `prek run --all-files` enabled for the actual project checks without changing the developer-side protection.