### PR TITLE
Prevent duplicate WebSocket listeners and callbacks

### DIFF
--- a/src/aioautomower/session.py
+++ b/src/aioautomower/session.py
@@ -135,7 +135,8 @@ class AutomowerSession:
         self, cb: Callable[[SingleMessageData], None]
     ) -> None:
         """Register a callback for the latest single message of a specific mower."""
-        self.single_message_cbs.append(cb)
+        if cb not in self.single_message_cbs:
+            self.single_message_cbs.append(cb)
 
     def unregister_single_message_callback(
         self,
@@ -156,7 +157,9 @@ class AutomowerSession:
         mower_id: str,
     ) -> None:
         """Register a callback triggered when new messages arrive for specific mower."""
-        self.message_update_cbs.append((mower_id, callback))
+        registration = (mower_id, callback)
+        if registration not in self.message_update_cbs:
+            self.message_update_cbs.append(registration)
 
     def unregister_message_callback(
         self,
@@ -164,7 +167,9 @@ class AutomowerSession:
         mower_id: str,
     ) -> None:
         """Unregister a previously registered message callback."""
-        self.message_update_cbs.remove((mower_id, callback))
+        registration = (mower_id, callback)
+        if registration in self.message_update_cbs:
+            self.message_update_cbs.remove(registration)
 
     def _schedule_message_callback(
         self,
@@ -326,8 +331,11 @@ class AutomowerSession:
 
     async def start_listening(self) -> None:
         """Start listening to the websocket."""
+        if self.ws_task and not self.ws_task.done():
+            return
         self.ws_task = self.loop.create_task(self._listen())
-        self.reconnect_task = self.loop.create_task(self._reconnect_scheduler())
+        if not self.reconnect_task or self.reconnect_task.done():
+            self.reconnect_task = self.loop.create_task(self._reconnect_scheduler())
 
     async def _reconnect_scheduler(self) -> None:
         """Reconnect scheduler."""
@@ -448,7 +456,7 @@ class AutomowerSession:
         return msg_resp
 
     def _update_data(self, new_data: GenericEventData) -> None:
-        """Update internal data with new data from websocket."""
+        """Update internal data from a websocket event."""
         if new_data["type"] == EventTypesV2.MESSAGES:
             if self.messages:
                 new_msg = Message.from_dict(new_data["attributes"]["message"])
@@ -489,10 +497,9 @@ class AutomowerSession:
         attributes: dict[str, Any] = new_data.get("attributes", {})
         for key, handler in handlers.items():
             if key in attributes:
-                handler(mower, attributes)  # Pass the specific attribute
+                handler(mower, attributes)
                 return
         mower_attributes = mower["attributes"]
-        # General handling for other attributes
         self._update_nested_dict(cast("dict[str, Any]", mower_attributes), attributes)
 
     def _handle_cutting_height_event(

--- a/tests/test_listener_registration.py
+++ b/tests/test_listener_registration.py
@@ -12,6 +12,7 @@ from aioautomower.session import AutomowerSession
 @pytest.mark.asyncio
 async def test_start_listening_is_idempotent(automower_client: AbstractAuth) -> None:
     """Starting the websocket listener repeatedly must not create duplicate tasks."""
+
     async def wait_forever(session: AutomowerSession) -> None:
         await asyncio.Event().wait()
 

--- a/tests/test_listener_registration.py
+++ b/tests/test_listener_registration.py
@@ -1,0 +1,45 @@
+"""Test websocket listener and callback registration."""
+
+import asyncio
+from unittest.mock import Mock, patch
+
+from aioautomower.auth import AbstractAuth
+from aioautomower.session import AutomowerSession
+
+
+async def test_start_listening_is_idempotent(automower_client: AbstractAuth) -> None:
+    """Starting the websocket listener repeatedly must not create duplicate tasks."""
+    async def wait_forever() -> None:
+        await asyncio.Event().wait()
+
+    automower_api = AutomowerSession(automower_client)
+    with (
+        patch.object(AutomowerSession, "_listen", new=wait_forever),
+        patch.object(AutomowerSession, "_reconnect_scheduler", new=wait_forever),
+    ):
+        await automower_api.start_listening()
+        ws_task = automower_api.ws_task
+        reconnect_task = automower_api.reconnect_task
+
+        await automower_api.start_listening()
+
+        assert automower_api.ws_task is ws_task
+        assert automower_api.reconnect_task is reconnect_task
+
+    await automower_api.close()
+
+
+def test_callback_registration_is_idempotent(
+    automower_client: AbstractAuth,
+) -> None:
+    """Registering the same callback repeatedly must only register it once."""
+    automower_api = AutomowerSession(automower_client)
+    callback = Mock()
+
+    automower_api.register_single_message_callback(callback)
+    automower_api.register_single_message_callback(callback)
+    automower_api.register_message_callback(callback, "mower-id")
+    automower_api.register_message_callback(callback, "mower-id")
+
+    assert automower_api.single_message_cbs == [callback]
+    assert automower_api.message_update_cbs == [("mower-id", callback)]

--- a/tests/test_listener_registration.py
+++ b/tests/test_listener_registration.py
@@ -3,13 +3,16 @@
 import asyncio
 from unittest.mock import Mock, patch
 
+import pytest
+
 from aioautomower.auth import AbstractAuth
 from aioautomower.session import AutomowerSession
 
 
+@pytest.mark.asyncio
 async def test_start_listening_is_idempotent(automower_client: AbstractAuth) -> None:
     """Starting the websocket listener repeatedly must not create duplicate tasks."""
-    async def wait_forever() -> None:
+    async def wait_forever(session: AutomowerSession) -> None:
         await asyncio.Event().wait()
 
     automower_api = AutomowerSession(automower_client)
@@ -29,7 +32,8 @@ async def test_start_listening_is_idempotent(automower_client: AbstractAuth) -> 
     await automower_api.close()
 
 
-def test_callback_registration_is_idempotent(
+@pytest.mark.asyncio
+async def test_callback_registration_is_idempotent(
     automower_client: AbstractAuth,
 ) -> None:
     """Registering the same callback repeatedly must only register it once."""


### PR DESCRIPTION
## Summary

- make `start_listening()` idempotent so repeated calls do not create multiple WebSocket listener or reconnect-scheduler tasks
- prevent duplicate single-message and message callbacks
- make message callback removal safe when the callback is already absent
- add regression tests covering repeated listener startup and callback registration

The current reconnect flow can call `start_listening()` from multiple paths. Previously every call created a new `_listen()` task and reconnect scheduler, which could result in duplicate processing of WebSocket events. This change keeps the existing task when it is still running and only creates a new scheduler when necessary.

The callback registration methods are also made consistent with the other callback APIs, which already avoid duplicate registrations.

## Testing

The PR adds regression tests for both task and callback registration behavior. GitHub Actions should validate the complete test suite and linting.